### PR TITLE
feat: Use GitHub API for data persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+*.log
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,167 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@octokit/rest": "^20.0.2",
         "express": "^4.18.2",
         "multer": "^1.4.5-lts.1"
       },
       "devDependencies": {
         "nodemon": "^3.0.1"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^8.4.1",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "11.4.4-cjs.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.4.4-cjs.2.tgz",
+      "integrity": "sha512-2dK6z8fhs8lla5PaOTgqfCGBxgAv/le+EhPs27KklPhm1bKObpu6lXzwfUEQ16ajXzqNrKMujsFyo9K2eaoISw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.7.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.1.tgz",
+      "integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "13.3.2-cjs.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.3.2-cjs.1.tgz",
+      "integrity": "sha512-VUjIjOOvF2oELQmiFpWA1aOPdawpyaCUqcEBc/UOUnj3Xp6DJGrJ1+bjUIIDzdHjnFNO6q57ODMfdEZnoBkCwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.8.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^5"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "20.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.2.tgz",
+      "integrity": "sha512-GmYiltypkHHtihFwPRxlaorG5R9VAHuk/vbszVoRTGXnAsY60wYLkh/E2XiFmdZmqrisw+9FaazS1i5SbdWYgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^5.0.2",
+        "@octokit/plugin-paginate-rest": "11.4.4-cjs.2",
+        "@octokit/plugin-request-log": "^4.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "13.3.2-cjs.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
       }
     },
     "node_modules/accepts": {
@@ -61,6 +217,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/before-after-hook": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -308,6 +470,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "license": "ISC"
     },
     "node_modules/destroy": {
       "version": "1.2.0",
@@ -948,6 +1116,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1371,6 +1548,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+      "license": "ISC"
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1403,6 +1586,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "description": "Foro web para intercambio de estudiantes",
   "dependencies": {
+    "@octokit/rest": "^20.0.2",
     "express": "^4.18.2",
     "multer": "^1.4.5-lts.1"
   },

--- a/publicaciones.js
+++ b/publicaciones.js
@@ -1,0 +1,80 @@
+const { Octokit } = require('@octokit/rest');
+
+// --- Configuración de GitHub ---
+// Es IMPERATIVO usar variables de entorno para estos valores en producción.
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const GITHUB_OWNER = process.env.GITHUB_OWNER;
+const GITHUB_REPO = process.env.GITHUB_REPO;
+const FILE_PATH = 'data/publicaciones.json';
+
+// --- Instancia de Octokit ---
+const octokit = new Octokit({
+  auth: GITHUB_TOKEN,
+});
+
+// --- Funciones para interactuar con la API de GitHub ---
+
+/**
+ * Obtiene el contenido del archivo de publicaciones desde GitHub.
+ * @returns {Promise<{data: Array, sha: string}>} - Un objeto con los datos y el SHA del archivo.
+ */
+async function getPublicaciones() {
+  try {
+    const response = await octokit.repos.getContent({
+      owner: GITHUB_OWNER,
+      repo: GITHUB_REPO,
+      path: FILE_PATH,
+    });
+
+    // El contenido viene en base64, hay que decodificarlo
+    const content = Buffer.from(response.data.content, 'base64').toString('utf-8');
+
+    return {
+      data: JSON.parse(content),
+      sha: response.data.sha, // El SHA es necesario para poder actualizar el archivo
+    };
+  } catch (error) {
+    // Si el archivo no existe (error 404), lo tratamos como una base de datos vacía.
+    if (error.status === 404) {
+      console.log('El archivo de publicaciones no existe en el repositorio. Se creará uno nuevo.');
+      return { data: [], sha: null }; // No hay SHA si el archivo no existe
+    }
+    // Si es otro tipo de error, lo lanzamos para que sea manejado más arriba.
+    console.error('Error al obtener publicaciones desde GitHub:', error);
+    throw new Error('No se pudieron obtener las publicaciones desde GitHub.');
+  }
+}
+
+/**
+ * Actualiza el archivo de publicaciones en GitHub.
+ * @param {Array} data - El nuevo array de publicaciones a guardar.
+ * @param {string} sha - El SHA del archivo que se va a actualizar. Si es null, se crea un nuevo archivo.
+ */
+async function updatePublicaciones(data, sha) {
+  try {
+    // Convertir los datos a formato JSON y luego a base64
+    const content = Buffer.from(JSON.stringify(data, null, 2)).toString('base64');
+
+    const message = sha
+      ? 'Actualiza publicaciones'
+      : 'Crea archivo de publicaciones';
+
+    await octokit.repos.createOrUpdateFileContents({
+      owner: GITHUB_OWNER,
+      repo: GITHUB_REPO,
+      path: FILE_PATH,
+      message: `${message} - ${new Date().toISOString()}`,
+      content: content,
+      sha: sha, // Si sha es null, Octokit crea el archivo. Si tiene valor, lo actualiza.
+    });
+
+  } catch (error) {
+    console.error('Error al actualizar publicaciones en GitHub:', error);
+    throw new Error('No se pudieron guardar los cambios en GitHub.');
+  }
+}
+
+module.exports = {
+  getPublicaciones,
+  updatePublicaciones,
+};

--- a/server.js
+++ b/server.js
@@ -2,6 +2,14 @@ const express = require('express');
 const fs = require('fs');
 const path = require('path');
 const multer = require('multer');
+const { getPublicaciones, updatePublicaciones } = require('./publicaciones');
+
+// --- Verificación de variables de entorno ---
+if (!process.env.GITHUB_TOKEN || !process.env.GITHUB_OWNER || !process.env.GITHUB_REPO) {
+  console.error('Error: Las variables de entorno GITHUB_TOKEN, GITHUB_OWNER, y GITHUB_REPO son obligatorias.');
+  process.exit(1); // Termina el proceso si las variables no están definidas
+}
+
 const app = express();
 const PORT = process.env.PORT || 3000;
 
@@ -9,23 +17,10 @@ const PORT = process.env.PORT || 3000;
 app.use(express.static('public'));
 app.use(express.json());
 
-// Verificar directorios necesarios
-const DATA_DIR = path.join(__dirname, 'data');
+// Verificar directorio para subidas (uploads)
 const UPLOADS_DIR = path.join(__dirname, 'public', 'uploads');
-
-if (!fs.existsSync(DATA_DIR)) {
-  fs.mkdirSync(DATA_DIR, { recursive: true });
-}
-
 if (!fs.existsSync(UPLOADS_DIR)) {
   fs.mkdirSync(UPLOADS_DIR, { recursive: true });
-}
-
-const DB_PATH = path.join(DATA_DIR, 'publicaciones.json');
-
-// Inicializar nueva base de datos si no existe
-if (!fs.existsSync(DB_PATH)) {
-  fs.writeFileSync(DB_PATH, JSON.stringify([], null, 2));
 }
 
 // Configuración de multer para subida de imágenes
@@ -34,16 +29,13 @@ const storage = multer.diskStorage({
     cb(null, UPLOADS_DIR);
   },
   filename: function(req, file, cb) {
-    // Generar nombre único para la imagen
     const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1E9);
     const ext = path.extname(file.originalname);
     cb(null, uniqueSuffix + ext);
   }
 });
 
-// Filtro para validar tipos de archivo
 const fileFilter = (req, file, cb) => {
-  // Aceptar solo imágenes
   if (file.mimetype.startsWith('image/')) {
     cb(null, true);
   } else {
@@ -51,9 +43,8 @@ const fileFilter = (req, file, cb) => {
   }
 };
 
-// Limitar tamaño a 2MB
-const upload = multer({ 
-  storage, 
+const upload = multer({
+  storage,
   fileFilter,
   limits: { fileSize: 2 * 1024 * 1024 } // 2MB
 });
@@ -66,11 +57,10 @@ function extraerEnlacesVideo(mensaje) {
     videoId: null,
     urlOriginal: null
   };
-  
-  // Regex para detectar enlaces de YouTube
+
   const youtubeRegex = /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/(?:watch\?v=|embed\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/;
   const youtubeMatch = mensaje.match(youtubeRegex);
-  
+
   if (youtubeMatch) {
     videoInfo.tieneVideo = true;
     videoInfo.plataforma = 'youtube';
@@ -78,11 +68,10 @@ function extraerEnlacesVideo(mensaje) {
     videoInfo.urlOriginal = youtubeMatch[0];
     return videoInfo;
   }
-  
-  // Regex para Vimeo (ejemplo: https://vimeo.com/123456789)
+
   const vimeoRegex = /(?:https?:\/\/)?(?:www\.)?vimeo\.com\/(\d+)/;
   const vimeoMatch = mensaje.match(vimeoRegex);
-  
+
   if (vimeoMatch) {
     videoInfo.tieneVideo = true;
     videoInfo.plataforma = 'vimeo';
@@ -90,28 +79,20 @@ function extraerEnlacesVideo(mensaje) {
     videoInfo.urlOriginal = vimeoMatch[0];
     return videoInfo;
   }
-  
-  // Ampliar aquí para más plataformas si es necesario
-  
+
   return videoInfo;
 }
 
-// Obtener todas las publicaciones
-// Obtener todas las publicaciones
-app.get('/api/publicaciones', (req, res) => {
+// --- Endpoints Refactorizados ---
+
+app.get('/api/publicaciones', async (req, res) => {
   try {
-    const data = JSON.parse(fs.readFileSync(DB_PATH, 'utf8'));
-    
-    // Si hay un parámetro de hashtag, filtrar las publicaciones
+    const { data } = await getPublicaciones();
     const hashtag = req.query.hashtag;
     if (hashtag) {
-      const filtradas = data.filter(pub => {
-        return pub.mensaje.toLowerCase().includes('#' + hashtag.toLowerCase());
-      });
+      const filtradas = data.filter(pub => pub.mensaje.toLowerCase().includes('#' + hashtag.toLowerCase()));
       return res.json(filtradas);
     }
-
-    // Si no hay hashtag, devolver todas
     res.json(data);
   } catch (error) {
     console.error('Error al leer publicaciones:', error);
@@ -119,22 +100,14 @@ app.get('/api/publicaciones', (req, res) => {
   }
 });
 
-// Obtener publicaciones ordenadas por votos (más votadas)
-app.get('/api/publicaciones/mas-votadas', (req, res) => {
+app.get('/api/publicaciones/mas-votadas', async (req, res) => {
   try {
-    const data = JSON.parse(fs.readFileSync(DB_PATH, 'utf8'));
+    const { data } = await getPublicaciones();
     const ordenadas = data.slice().sort((a, b) => {
       const votosA = (a.likes || 0) - (a.dislikes || 0);
       const votosB = (b.likes || 0) - (b.dislikes || 0);
-
-      if (votosB !== votosA) {
-        return votosB - votosA; // Ordena por score descendente
-      }
-
-      // Si empate en votos, ordena por fecha más reciente
-      const fechaA = new Date(a.fecha);
-      const fechaB = new Date(b.fecha);
-      return fechaB - fechaA;
+      if (votosB !== votosA) return votosB - votosA;
+      return new Date(b.fecha) - new Date(a.fecha);
     });
     res.json(ordenadas);
   } catch (error) {
@@ -143,36 +116,27 @@ app.get('/api/publicaciones/mas-votadas', (req, res) => {
   }
 });
 
-// Agregar puntuación con estrellas a una publicación
-app.post('/api/publicaciones/:id/estrella', (req, res) => {
+app.post('/api/publicaciones/:id/estrella', async (req, res) => {
   try {
-    const data = JSON.parse(fs.readFileSync(DB_PATH, 'utf8'));
+    const { data, sha } = await getPublicaciones();
     const id = parseInt(req.params.id);
-    const { valor } = req.body; // valor debe ser un número entre 1 y 5
+    const { valor } = req.body;
 
     if (![1, 2, 3, 4, 5].includes(valor)) {
       return res.status(400).json({ error: 'Valor de estrella inválido. Debe ser entre 1 y 5.' });
     }
 
     const publicacion = data.find(pub => pub.id === id);
-    if (!publicacion) {
-      return res.status(404).json({ error: 'Publicación no encontrada' });
-    }
+    if (!publicacion) return res.status(404).json({ error: 'Publicación no encontrada' });
 
-    // Inicializar array si no existe
-    if (!Array.isArray(publicacion.estrellas)) {
-      publicacion.estrellas = [];
-    }
-
+    if (!Array.isArray(publicacion.estrellas)) publicacion.estrellas = [];
     publicacion.estrellas.push(valor);
 
-    fs.writeFileSync(DB_PATH, JSON.stringify(data, null, 2));
+    await updatePublicaciones(data, sha);
     res.json({
       mensaje: 'Estrella agregada con éxito',
       total: publicacion.estrellas.length,
-      promedio: (
-        publicacion.estrellas.reduce((a, b) => a + b, 0) / publicacion.estrellas.length
-      ).toFixed(2)
+      promedio: (publicacion.estrellas.reduce((a, b) => a + b, 0) / publicacion.estrellas.length).toFixed(2)
     });
   } catch (error) {
     console.error('Error al agregar estrella:', error);
@@ -180,21 +144,14 @@ app.post('/api/publicaciones/:id/estrella', (req, res) => {
   }
 });
 
-
-// Obtener todos los hashtags únicos
-app.get('/api/hashtags', (req, res) => {
+app.get('/api/hashtags', async (req, res) => {
   try {
-    const data = JSON.parse(fs.readFileSync(DB_PATH, 'utf8'));
+    const { data } = await getPublicaciones();
     const hashtags = new Set();
-    
-    // Extraer hashtags de todos los mensajes
     data.forEach(pub => {
       const matches = pub.mensaje.match(/#\w+/g);
-      if (matches) {
-        matches.forEach(tag => hashtags.add(tag.substring(1).toLowerCase()));
-      }
+      if (matches) matches.forEach(tag => hashtags.add(tag.substring(1).toLowerCase()));
     });
-    
     res.json(Array.from(hashtags));
   } catch (error) {
     console.error('Error al leer hashtags:', error);
@@ -202,18 +159,13 @@ app.get('/api/hashtags', (req, res) => {
   }
 });
 
-// Crear nueva publicación o responder a una existente
-app.post('/api/publicaciones', upload.single('imagen'), (req, res) => {
+app.post('/api/publicaciones', upload.single('imagen'), async (req, res) => {
   try {
-    const data = JSON.parse(fs.readFileSync(DB_PATH, 'utf8'));
+    const { data, sha } = await getPublicaciones();
     const nueva = req.body;
 
-    // Si hay imagen subida, guardar su ruta
-    if (req.file) {
-      nueva.imagen = `/uploads/${req.file.filename}`;
-    }
-    
-    // Procesar el mensaje para detectar enlaces de video
+    if (req.file) nueva.imagen = `/uploads/${req.file.filename}`;
+
     const videoInfo = extraerEnlacesVideo(nueva.mensaje);
     if (videoInfo.tieneVideo) {
       nueva.video = {
@@ -223,54 +175,34 @@ app.post('/api/publicaciones', upload.single('imagen'), (req, res) => {
       };
     }
 
-    // Reemplaza la sección de "Nueva publicación" en tu endpoint POST /api/publicaciones
-// por esta versión que incluye inicialización de emojiCounts:
-
-if (nueva.respuestaA !== undefined) {
-  // Es una réplica
-  const original = data.find(pub => pub.id === parseInt(nueva.respuestaA));
-  if (!original) {
-    return res.status(404).json({ error: 'Publicación original no encontrada' });
-  }
-  original.replicas = original.replicas || [];
-  
-  const nuevaReplica = {
-    nombre: nueva.nombre,
-    mensaje: nueva.mensaje,
-    fecha: new Date().toISOString(),
-    imagen: nueva.imagen,
-    likes: 0,
-    dislikes: 0,
-    genero: nueva.genero, // Asegurar que se guarde el género
-    emojiCounts: {} // Inicializar contadores de emojis para respuestas
-  };
-  
-  // Agregar información del video si existe
-  if (videoInfo.tieneVideo) {
-    nuevaReplica.video = nueva.video;
-  }
-  
-  original.replicas.push(nuevaReplica);
-} else {
-  // Nueva publicación
-  nueva.id = Date.now();
-  nueva.fecha = new Date().toISOString();
-  nueva.replicas = [];
-  nueva.likes = 0;
-  nueva.dislikes = 0;
-  nueva.emojiCounts = {}; // Inicializar contadores de emojis
-  
-  // Extraer hashtags del mensaje
-  const matches = nueva.mensaje.match(/#\w+/g);
-  if (matches) {
-    nueva.hashtags = matches.map(tag => tag.substring(1).toLowerCase());
-  } else {
-    nueva.hashtags = [];
-  }
-  
-  data.push(nueva);
-}
-    fs.writeFileSync(DB_PATH, JSON.stringify(data, null, 2));
+    if (nueva.respuestaA !== undefined) {
+      const original = data.find(pub => pub.id === parseInt(nueva.respuestaA));
+      if (!original) return res.status(404).json({ error: 'Publicación original no encontrada' });
+      original.replicas = original.replicas || [];
+      const nuevaReplica = {
+        nombre: nueva.nombre,
+        mensaje: nueva.mensaje,
+        fecha: new Date().toISOString(),
+        imagen: nueva.imagen,
+        likes: 0,
+        dislikes: 0,
+        genero: nueva.genero,
+        emojiCounts: {}
+      };
+      if (videoInfo.tieneVideo) nuevaReplica.video = nueva.video;
+      original.replicas.push(nuevaReplica);
+    } else {
+      nueva.id = Date.now();
+      nueva.fecha = new Date().toISOString();
+      nueva.replicas = [];
+      nueva.likes = 0;
+      nueva.dislikes = 0;
+      nueva.emojiCounts = {};
+      const matches = nueva.mensaje.match(/#\w+/g);
+      nueva.hashtags = matches ? matches.map(tag => tag.substring(1).toLowerCase()) : [];
+      data.push(nueva);
+    }
+    await updatePublicaciones(data, sha);
     res.status(201).json({ mensaje: 'Guardado con éxito' });
   } catch (error) {
     console.error('Error al guardar publicación:', error);
@@ -278,69 +210,156 @@ if (nueva.respuestaA !== undefined) {
   }
 });
 
-// Nuevo endpoint para manejar los likes/dislikes de una publicación principal
-app.post('/api/publicaciones/:id/voto', (req, res) => {
+app.post('/api/publicaciones/:id/voto', async (req, res) => {
   try {
-    const data = JSON.parse(fs.readFileSync(DB_PATH, 'utf8'));
+    const { data, sha } = await getPublicaciones();
     const id = parseInt(req.params.id);
-    const { tipo } = req.body; // 'like' o 'dislike'
-    
-    // Encontrar la publicación por ID
+    const { tipo } = req.body;
+
     const publicacion = data.find(pub => pub.id === id);
-    
-    if (!publicacion) {
-      return res.status(404).json({ error: 'Publicación no encontrada' });
-    }
-    
-    // Incrementar el contador correspondiente
-    if (tipo === 'like') {
-      publicacion.likes = (publicacion.likes || 0) + 1;
-    } else if (tipo === 'dislike') {
-      publicacion.dislikes = (publicacion.dislikes || 0) + 1;
-    }
-    
-    fs.writeFileSync(DB_PATH, JSON.stringify(data, null, 2));
-    res.json({ 
-      likes: publicacion.likes, 
-      dislikes: publicacion.dislikes 
-    });
+    if (!publicacion) return res.status(404).json({ error: 'Publicación no encontrada' });
+
+    if (tipo === 'like') publicacion.likes = (publicacion.likes || 0) + 1;
+    else if (tipo === 'dislike') publicacion.dislikes = (publicacion.dislikes || 0) + 1;
+
+    await updatePublicaciones(data, sha);
+    res.json({ likes: publicacion.likes, dislikes: publicacion.dislikes });
   } catch (error) {
     console.error('Error al procesar voto:', error);
     res.status(500).json({ error: 'Error al procesar el voto' });
   }
 });
 
-// Nuevo endpoint para manejar los likes/dislikes de una respuesta
-app.post('/api/publicaciones/:id/respuesta/:indice/voto', (req, res) => {
+app.post('/api/publicaciones/:id/respuesta/:indice/voto', async (req, res) => {
   try {
-    const data = JSON.parse(fs.readFileSync(DB_PATH, 'utf8'));
+    const { data, sha } = await getPublicaciones();
     const id = parseInt(req.params.id);
     const indice = parseInt(req.params.indice);
-    const { tipo } = req.body; // 'like' o 'dislike'
-    
-    // Encontrar la publicación principal por ID
+    const { tipo } = req.body;
+
     const publicacion = data.find(pub => pub.id === id);
-    
     if (!publicacion || !publicacion.replicas || !publicacion.replicas[indice]) {
       return res.status(404).json({ error: 'Respuesta no encontrada' });
     }
-    
-    // Incrementar el contador correspondiente en la respuesta
+
     const respuesta = publicacion.replicas[indice];
-    if (tipo === 'like') {
-      respuesta.likes = (respuesta.likes || 0) + 1;
-    } else if (tipo === 'dislike') {
-      respuesta.dislikes = (respuesta.dislikes || 0) + 1;
-    }
-    
-    fs.writeFileSync(DB_PATH, JSON.stringify(data, null, 2));
-    res.json({ 
-      likes: respuesta.likes, 
-      dislikes: respuesta.dislikes 
-    });
+    if (tipo === 'like') respuesta.likes = (respuesta.likes || 0) + 1;
+    else if (tipo === 'dislike') respuesta.dislikes = (respuesta.dislikes || 0) + 1;
+
+    await updatePublicaciones(data, sha);
+    res.json({ likes: respuesta.likes, dislikes: respuesta.dislikes });
   } catch (error) {
     console.error('Error al procesar voto en respuesta:', error);
     res.status(500).json({ error: 'Error al procesar el voto en la respuesta' });
+  }
+});
+
+app.get('/api/publicaciones/:id', async (req, res) => {
+  try {
+    const { data } = await getPublicaciones();
+    const publicacion = data.find(p => p.id === parseInt(req.params.id));
+    if (!publicacion) return res.status(404).json({ error: 'Publicación no encontrada' });
+    res.json(publicacion);
+  } catch (error) {
+    console.error('Error al obtener publicación:', error);
+    res.status(500).json({ error: 'Error al obtener la publicación' });
+  }
+});
+
+app.post('/api/publicaciones/:id/emoji-reaction', async (req, res) => {
+  try {
+    const { data, sha } = await getPublicaciones();
+    const id = parseInt(req.params.id);
+    const { emoji, action } = req.body;
+
+    const EMOJIS_PERMITIDOS = ['👍', '😂', '❤️', '🤔', '😢', '😮'];
+    if (!EMOJIS_PERMITIDOS.includes(emoji)) return res.status(400).json({ error: 'Emoji no permitido' });
+    if (!['add', 'remove'].includes(action)) return res.status(400).json({ error: 'Acción no válida' });
+
+    const publicacion = data.find(pub => pub.id === id);
+    if (!publicacion) return res.status(404).json({ error: 'Publicación no encontrada' });
+
+    publicacion.emojiCounts = publicacion.emojiCounts || {};
+    publicacion.emojiCounts[emoji] = publicacion.emojiCounts[emoji] || 0;
+
+    if (action === 'add') publicacion.emojiCounts[emoji] += 1;
+    else if (action === 'remove') publicacion.emojiCounts[emoji] = Math.max(0, publicacion.emojiCounts[emoji] - 1);
+
+    await updatePublicaciones(data, sha);
+    res.json({ success: true, count: publicacion.emojiCounts[emoji] });
+  } catch (error) {
+    console.error('Error al procesar reacción de emoji:', error);
+    res.status(500).json({ error: 'Error al procesar la reacción' });
+  }
+});
+
+app.get('/api/publicaciones/:id/emoji-reactions', async (req, res) => {
+  try {
+    const { data } = await getPublicaciones();
+    const publicacion = data.find(pub => pub.id === parseInt(req.params.id));
+    if (!publicacion) return res.status(404).json({ error: 'Publicación no encontrada' });
+    res.json({ publicacionId: publicacion.id, emojiCounts: publicacion.emojiCounts || {} });
+  } catch (error) {
+    console.error('Error al obtener reacciones de emoji:', error);
+    res.status(500).json({ error: 'Error al obtener las reacciones' });
+  }
+});
+
+app.post('/api/publicaciones/:id/respuesta/:indice/emoji-reaction', async (req, res) => {
+  try {
+    const { data, sha } = await getPublicaciones();
+    const id = parseInt(req.params.id);
+    const indice = parseInt(req.params.indice);
+    const { emoji, action } = req.body;
+
+    if (!['👍', '😂', '❤️', '🤔', '😢', '😮'].includes(emoji)) return res.status(400).json({ error: 'Emoji no permitido' });
+    if (!['add', 'remove'].includes(action)) return res.status(400).json({ error: 'Acción no válida' });
+
+    const publicacion = data.find(pub => pub.id === id);
+    if (!publicacion || !publicacion.replicas || !publicacion.replicas[indice]) {
+      return res.status(404).json({ error: 'Respuesta no encontrada' });
+    }
+
+    const respuesta = publicacion.replicas[indice];
+    respuesta.emojiCounts = respuesta.emojiCounts || {};
+    respuesta.emojiCounts[emoji] = respuesta.emojiCounts[emoji] || 0;
+
+    if (action === 'add') respuesta.emojiCounts[emoji] += 1;
+    else if (action === 'remove') respuesta.emojiCounts[emoji] = Math.max(0, respuesta.emojiCounts[emoji] - 1);
+
+    await updatePublicaciones(data, sha);
+    res.json({ success: true, count: respuesta.emojiCounts[emoji] });
+  } catch (error) {
+    console.error('Error al procesar reacción de emoji en respuesta:', error);
+    res.status(500).json({ error: 'Error al procesar la reacción' });
+  }
+});
+
+app.get('/api/emoji-stats', async (req, res) => {
+  try {
+    const { data } = await getPublicaciones();
+    const stats = {};
+
+    const countEmojis = (item) => {
+      if (item.emojiCounts) {
+        Object.entries(item.emojiCounts).forEach(([emoji, count]) => {
+          stats[emoji] = (stats[emoji] || 0) + count;
+        });
+      }
+    };
+
+    data.forEach(pub => {
+      countEmojis(pub);
+      if (pub.replicas) pub.replicas.forEach(resp => countEmojis(resp));
+    });
+
+    res.json({
+      totalReactions: Object.values(stats).reduce((sum, count) => sum + count, 0),
+      emojiStats: stats
+    });
+  } catch (error) {
+    console.error('Error al obtener estadísticas de emojis:', error);
+    res.status(500).json({ error: 'Error al obtener estadísticas' });
   }
 });
 
@@ -357,207 +376,4 @@ app.use((err, req, res, next) => {
 
 app.listen(PORT, () => {
   console.log(`Servidor corriendo en http://localhost:${PORT}`);
-});
-
-// En server.js (ruta sugerida)
-// En server.js, el endpoint correcto debería ser:
-app.get('/api/publicaciones/:id', (req, res) => {
-  try {
-    const data = JSON.parse(fs.readFileSync(DB_PATH, 'utf8'));
-    const publicacionId = parseInt(req.params.id);
-    const publicacion = data.find(p => p.id === publicacionId);
-    
-    if (!publicacion) {
-      return res.status(404).json({ error: 'Publicación no encontrada' });
-    }
-    
-    res.json(publicacion);
-  } catch (error) {
-    console.error('Error al obtener publicación:', error);
-    res.status(500).json({ error: 'Error al obtener la publicación' });
-  }
-});
-
-// Agregar estos endpoints a tu server.js después de los endpoints existentes
-
-// Endpoint para manejar reacciones de emojis en publicaciones
-app.post('/api/publicaciones/:id/emoji-reaction', (req, res) => {
-  try {
-    const data = JSON.parse(fs.readFileSync(DB_PATH, 'utf8'));
-    const id = parseInt(req.params.id);
-    const { emoji, action } = req.body; // action: 'add' o 'remove'
-    
-    // Validar que el emoji esté en la lista permitida
-    const EMOJIS_PERMITIDOS = ['👍', '😂', '❤️', '🤔', '😢', '😮'];
-    if (!EMOJIS_PERMITIDOS.includes(emoji)) {
-      return res.status(400).json({ error: 'Emoji no permitido' });
-    }
-    
-    // Validar acción
-    if (!['add', 'remove'].includes(action)) {
-      return res.status(400).json({ error: 'Acción no válida. Use "add" o "remove"' });
-    }
-    
-    // Encontrar la publicación por ID
-    const publicacion = data.find(pub => pub.id === id);
-    
-    if (!publicacion) {
-      return res.status(404).json({ error: 'Publicación no encontrada' });
-    }
-    
-    // Inicializar el objeto emojiCounts si no existe
-    if (!publicacion.emojiCounts) {
-      publicacion.emojiCounts = {};
-    }
-    
-    // Inicializar el contador del emoji si no existe
-    if (typeof publicacion.emojiCounts[emoji] === 'undefined') {
-      publicacion.emojiCounts[emoji] = 0;
-    }
-    
-    // Procesar la acción
-    if (action === 'add') {
-      publicacion.emojiCounts[emoji] += 1;
-    } else if (action === 'remove') {
-      publicacion.emojiCounts[emoji] = Math.max(0, publicacion.emojiCounts[emoji] - 1);
-    }
-    
-    // Guardar los cambios
-    fs.writeFileSync(DB_PATH, JSON.stringify(data, null, 2));
-    
-    res.json({ 
-      success: true,
-      emoji: emoji,
-      count: publicacion.emojiCounts[emoji],
-      action: action
-    });
-    
-  } catch (error) {
-    console.error('Error al procesar reacción de emoji:', error);
-    res.status(500).json({ error: 'Error interno del servidor al procesar la reacción' });
-  }
-});
-
-// Endpoint para obtener las reacciones de emojis de una publicación específica
-app.get('/api/publicaciones/:id/emoji-reactions', (req, res) => {
-  try {
-    const data = JSON.parse(fs.readFileSync(DB_PATH, 'utf8'));
-    const id = parseInt(req.params.id);
-    
-    const publicacion = data.find(pub => pub.id === id);
-    
-    if (!publicacion) {
-      return res.status(404).json({ error: 'Publicación no encontrada' });
-    }
-    
-    // Devolver las reacciones de emojis o un objeto vacío si no existen
-    const emojiCounts = publicacion.emojiCounts || {};
-    
-    res.json({
-      publicacionId: id,
-      emojiCounts: emojiCounts
-    });
-    
-  } catch (error) {
-    console.error('Error al obtener reacciones de emoji:', error);
-    res.status(500).json({ error: 'Error al obtener las reacciones' });
-  }
-});
-
-// Endpoint para manejar reacciones de emojis en respuestas/réplicas
-app.post('/api/publicaciones/:id/respuesta/:indice/emoji-reaction', (req, res) => {
-  try {
-    const data = JSON.parse(fs.readFileSync(DB_PATH, 'utf8'));
-    const id = parseInt(req.params.id);
-    const indice = parseInt(req.params.indice);
-    const { emoji, action } = req.body;
-    
-    // Validar que el emoji esté en la lista permitida
-    const EMOJIS_PERMITIDOS = ['👍', '😂', '❤️', '🤔', '😢', '😮'];
-    if (!EMOJIS_PERMITIDOS.includes(emoji)) {
-      return res.status(400).json({ error: 'Emoji no permitido' });
-    }
-    
-    // Validar acción
-    if (!['add', 'remove'].includes(action)) {
-      return res.status(400).json({ error: 'Acción no válida. Use "add" o "remove"' });
-    }
-    
-    // Encontrar la publicación principal por ID
-    const publicacion = data.find(pub => pub.id === id);
-    
-    if (!publicacion || !publicacion.replicas || !publicacion.replicas[indice]) {
-      return res.status(404).json({ error: 'Respuesta no encontrada' });
-    }
-    
-    const respuesta = publicacion.replicas[indice];
-    
-    // Inicializar el objeto emojiCounts si no existe
-    if (!respuesta.emojiCounts) {
-      respuesta.emojiCounts = {};
-    }
-    
-    // Inicializar el contador del emoji si no existe
-    if (typeof respuesta.emojiCounts[emoji] === 'undefined') {
-      respuesta.emojiCounts[emoji] = 0;
-    }
-    
-    // Procesar la acción
-    if (action === 'add') {
-      respuesta.emojiCounts[emoji] += 1;
-    } else if (action === 'remove') {
-      respuesta.emojiCounts[emoji] = Math.max(0, respuesta.emojiCounts[emoji] - 1);
-    }
-    
-    // Guardar los cambios
-    fs.writeFileSync(DB_PATH, JSON.stringify(data, null, 2));
-    
-    res.json({ 
-      success: true,
-      emoji: emoji,
-      count: respuesta.emojiCounts[emoji],
-      action: action
-    });
-    
-  } catch (error) {
-    console.error('Error al procesar reacción de emoji en respuesta:', error);
-    res.status(500).json({ error: 'Error interno del servidor al procesar la reacción' });
-  }
-});
-
-// Endpoint para obtener estadísticas globales de emojis (opcional)
-app.get('/api/emoji-stats', (req, res) => {
-  try {
-    const data = JSON.parse(fs.readFileSync(DB_PATH, 'utf8'));
-    const stats = {};
-    
-    // Contar emojis en publicaciones principales
-    data.forEach(pub => {
-      if (pub.emojiCounts) {
-        Object.entries(pub.emojiCounts).forEach(([emoji, count]) => {
-          stats[emoji] = (stats[emoji] || 0) + count;
-        });
-      }
-      
-      // Contar emojis en respuestas
-      if (pub.replicas) {
-        pub.replicas.forEach(resp => {
-          if (resp.emojiCounts) {
-            Object.entries(resp.emojiCounts).forEach(([emoji, count]) => {
-              stats[emoji] = (stats[emoji] || 0) + count;
-            });
-          }
-        });
-      }
-    });
-    
-    res.json({
-      totalReactions: Object.values(stats).reduce((sum, count) => sum + count, 0),
-      emojiStats: stats
-    });
-    
-  } catch (error) {
-    console.error('Error al obtener estadísticas de emojis:', error);
-    res.status(500).json({ error: 'Error al obtener estadísticas' });
-  }
 });


### PR DESCRIPTION
This commit refactors the application to use the GitHub API for storing and retrieving forum posts, replacing the previous file system-based approach. This change is necessary for the application to function correctly on hosting platforms with ephemeral or read-only filesystems, such as Render.

Key changes:
- Adds the `@octokit/rest` dependency to interact with the GitHub API.
- Creates a new `publicaciones.js` module to encapsulate all GitHub API logic for fetching and updating the `publicaciones.json` file.
- Refactors `server.js` to replace all `fs.readFileSync` and `fs.writeFileSync` calls with asynchronous calls to the new module.
- Removes hardcoded API tokens and repository information, now relying on environment variables (`GITHUB_TOKEN`, `GITHUB_OWNER`, `GITHUB_REPO`).
- Adds a startup check to ensure all required environment variables are present.
- Adds a `.gitignore` file to exclude `node_modules` and other unnecessary files from version control.