### PR TITLE
fix: Correct image encoding to prevent corruption

### DIFF
--- a/publicaciones.js
+++ b/publicaciones.js
@@ -92,8 +92,8 @@ async function uploadImage(file) {
     const fileName = `${uniqueSuffix}${ext}`;
     const filePath = `public/uploads/${fileName}`;
 
-    // Convertir el buffer del archivo a base64
-    const content = file.buffer.toString('base64');
+    // Convertir el buffer del archivo a base64 de forma explícita para evitar corrupción
+    const content = Buffer.from(file.buffer).toString('base64');
 
     await octokit.repos.createOrUpdateFileContents({
       owner: GITHUB_OWNER,


### PR DESCRIPTION
This commit addresses an issue where uploaded images were being corrupted during the upload process to GitHub.

The problem was caused by a subtle issue in how the image buffer was being converted to a Base64 string. The fix ensures an explicit and robust conversion by using `Buffer.from(file.buffer).toString('base64')`.

This change should ensure the integrity of the image data and resolve the issue of images appearing as damaged on the website.